### PR TITLE
Depend on mssql v0.2.2

### DIFF
--- a/pack.yaml
+++ b/pack.yaml
@@ -14,4 +14,4 @@ author: stanley
 email: stanley@localhost.local
 dependencies:
   - https://github.com/StackStorm/stackstorm-ms.git
-  - mssql=0.2.1
+  - mssql=0.2.2


### PR DESCRIPTION
mssql pack v0.2.1 does not pin the pymssql package to `<3.0`, so that package raises an exception on installation.

The pack v0.2.2 will pin pymssql to `<3.0` to allow the package to install.

This PR updates the mssql pack dependency version to 0.2.2.

This is required to get the ST2 CI test "Successfully install the parent ms pack" for the `st2` CLI passing again.